### PR TITLE
Bullseye support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@
 # backwards compatibility). Please don't change it unless you know what
 # you're doing.
 Vagrant.configure(2) do |config|
-  config.vm.box = "debian-9-amd64"
+  config.vm.box = "debian/bullseye64"
 
   config.ssh.insert_key = false
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,6 +29,11 @@ sudo apt-get update >/dev/null 2>/dev/null
     end
   end
 
+  # Install puppet and requirements
+  config.vm.provision :shell do |s|
+    s.inline = "sudo apt-get -y install puppet tzdata util-linux lsb-release augeas-tools pciutils"
+  end
+
   config.vm.provision :puppet do |puppet|
     puppet.manifests_path = "manifests"
     puppet.manifest_file  = "default.pp"

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -73,9 +73,12 @@ package { [
 }
 
 
-# Facter in Debian Buster uses this
+# Facter as from Debian Buster uses this
 if $facts['os'] {
-  if versioncmp($facts['os']['release']['major'], '10') >= 0 {
+  if versioncmp($facts['os']['release']['major'], '11') >= 0 {
+    $has_phpmyadmin = false
+    $php = '7.4'
+  } elsif versioncmp($facts['os']['release']['major'], '10') >= 0 {
     $has_phpmyadmin = false
     $php = '7.3'
   } else {
@@ -83,7 +86,10 @@ if $facts['os'] {
     $php = '7.0'
   }
 } elsif $facts['lsbdistrelease'] {
-  if versioncmp($facts['lsbdistrelease'], '10') >= 0 {
+  if versioncmp($facts['lsbdistrelease'], '11') >= 0 {
+    $has_phpmyadmin = false
+    $php = '7.4'
+  } elsif versioncmp($facts['lsbdistrelease'], '10') >= 0 {
     $has_phpmyadmin = false
     $php = '7.3'
   } else {

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -176,7 +176,7 @@ package { 'alternc':
   provider => 'dpkg',
   source   => '/vagrant/alternc_3.5.0~rc1_all.deb',
   require  => Exec['preseeding'],
-  #notify   => Exec['alternc.install'],
+  notify   => Exec['alternc.install'],
 }
 
 # Finish installation: the package doesn't finish its job

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -37,7 +37,6 @@ package { [
   'dovecot-pop3d',
   'dovecot-sieve',
   'gettext',
-  'incron',
   'libapache2-mpm-itk',
   'libjs-jquery-tablesorter',
   'libjs-jquery-ui',


### PR DESCRIPTION
* remove incron from packages list which isn't supported in bullseye (moved to suggested packages in alternc - see https://github.com/Koumbit/AlternC/commit/710231ea97390de1032f0b82f2a9f2a210877b70)
* add default php version for bullseye
* use bullseye as the base box
* changes to make alternc ready out-of-the-box on the VM (install puppet prior to puppet run + check hostname to avoid silent fail on default user creation - see https://github.com/AlternC/AlternC/issues/510)